### PR TITLE
Update '1' and nightly versions versions

### DIFF
--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -19,7 +19,7 @@ if ($env:PLATFORM -eq "x86") {
 
 if ($env:JULIA_VERSION -in 'latest', 'nightly') {
     # TODO: move to nightly to be consistent with Travis and download page
-    $julia_version = [Version]"1.5"
+    $julia_version = [Version]"1.11"
     $julia_url = "https://julialangnightlies-s3.julialang.org/bin/winnt/$platform/julia-latest-win$wordsize.exe"
 } elseif ($env:JULIA_VERSION -match "(\d*\.\d*)\.\d*") {
     $julia_version = [Version]$matches[1]
@@ -28,7 +28,7 @@ if ($env:JULIA_VERSION -in 'latest', 'nightly') {
     if ($env:JULIA_VERSION -eq 'release') {
         Write-Error "'release' is no longer a supported version, use '1' instead."
     } elseif ($env:JULIA_VERSION -eq '1') {
-        $julia_version = [Version]"1.5"
+        $julia_version = [Version]"1.9"
     } elseif ($env:JULIA_VERSION -match "\d*\.\d*") {
         $julia_version = [Version]$env:JULIA_VERSION
     } else {


### PR DESCRIPTION
Seems these have not been updated in a long time. Maybe using '1' is no longer recommended; the default appveyor script generated by `PkgTemplates.jl' specifies 1.9 by default. But for consistency with the other CI platforms this would be nice.